### PR TITLE
Lightweight system zlib wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +30,18 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -56,10 +74,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "libz-sys",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "gzip"
 version = "1.90.0"
 dependencies = [
  "clap",
+ "flate2",
+ "libz-sys",
 ]
 
 [[package]]
@@ -106,10 +148,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
+name = "libz-sys"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -119,6 +182,12 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "proc-macro-error"
@@ -199,6 +268,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ version = "1.90.0"
 dependencies = [
  "clap",
  "flate2",
+ "libc",
  "libz-sys",
 ]
 
@@ -143,9 +144,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "libz-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -45,16 +45,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.6"
+version = "3.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1957aa4a5fb388f0a0a73ce7556c5b42025b874e5cdc2c670775e346e97adec0"
+checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
@@ -62,15 +62,24 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -128,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -161,23 +170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "memchr"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,9 +183,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "pkg-config"
@@ -227,18 +216,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -251,9 +240,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -262,18 +251,18 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.0.6", features = ["derive"] }
 flate2 = { version = "1.0", features = ["zlib"] }
+libz-sys = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 clap = { version = "3.0.6", features = ["derive"] }
 flate2 = { version = "1.0", features = ["zlib"] }
 libz-sys = "1"
+libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.0.6", features = ["derive"] }
 flate2 = { version = "1.0", features = ["zlib"] }
-libz-sys = "1"
+libz-sys = { version = "1", features = ["libc"] }
 libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,120 +1,140 @@
 //! An [RFC 1952](https://datatracker.ietf.org/doc/html/rfc1952)-correct description
 //! of the gzip file format in Rust.
+//! 
+//! To use the library, create a [Reader] or [Writer] with an underlying data structure
+//! implementing [Read] or [Write], respectively. Libz stream initialization and management
+//! is carried out automatically.
 
 use std::{
-    convert,
     io::{self, Read, Write},
-    result,
+    ptr::null_mut,
 };
 
+use libc::c_void;
 use libz_sys::*;
 
-/// Magic number identifying a gzip archive.
-const GZIP_MAGIC: [u8; 2] = [0o037, 0o213];
-/// Magic number for older gzip archives.
-const OLD_GZIP_MAGIC: [u8; 2] = [0o37, 0o236];
-const LZH_MAGIC: [u8; 2] = [0o037, 0o236];
-const PKZIP_MAGIC: [u8; 4] = [0o120, 0o113, 0o003, 0o004];
+/// Custom memory allocation handler for libz.
+unsafe extern "C" fn mem_alloc(_opaque: *mut c_void, _val: u32, size: u32) -> *mut c_void {
+    libc::malloc(size as usize)
+}
 
-/// OS codes used by the gzip format.
+/// Custom memory deallocation handler for libz.
+unsafe extern "C" fn mem_free(_opaque: *mut c_void, ptr: *mut c_void) {
+    libc::free(ptr)
+}
+
+#[repr(C)]
 #[derive(Debug, Clone, Copy)]
-#[repr(u8)]
-pub enum OsCode {
-    FAT = 0,
-    AMIGA = 1,
-    VMS = 2,
-    UNIX = 3,
-    VMCMS = 4,
-    ATARI = 5,
-    HPFS = 6,
-    MACINTOSH = 7,
-    ZSYSTEM = 8,
-    CPM = 9,
-    TOPS = 10,
-
-    /// Windows' preferred file system. The successor to FAT.
-    NTFS = 11,
-
-    QDOS = 12,
-    ACORN = 13,
-
-    /// Provided for historical reasons.
-    UNKNOWN = 255,
+enum Mode {
+    INFLATE,
+    DEFLATE,
 }
 
-/// A member in a gzip file.
-///
-/// A gzip file consists of a series of "members" (compressed data sets). The
-/// format of each member is specified in the following data structure.
-/// The members simply appear one after another in the file,
-/// with no additional information before, between, or after them.
-///
-/// See: [RFC 1952](https://datatracker.ietf.org/doc/html/rfc1952)
-#[derive(Debug, Clone)]
-pub struct Member {
-    /// Method used in compressing this member.
-    method: Method,
-
-    /// One-hot byte enabling extra fields in a gzip member.
-    flags: u8,
-
-    /// Most recent modification time of the compressed file.
-    mtime: u32,
-
-    /// Provided if [Flag::ExtraField] is set.
-    extra_field: Option<Subfield>,
-
-    /// Zero-terminated string containing the original file name, if [Flag::Name] is set.
-    name: Option<String>,
-
-    /// Zero-terminated file comment, if [Flag::Comment] is set.
-    comment: Option<String>,
-
-    /// CRC-16 of the gzip header, provided if [Flag::HeaderCrc] is set.
-    crc_16: Option<u16>,
-
-    /// Data associated with this member.
-    data: Vec<u8>,
-
-    /// CRC-32 of the original, uncompressed file.
-    crc_32: u32,
-
-    /// Size of the original, uncompressed file mod 2^32.
-    size: u32,
+/// Safety-wrapped representation of a libz stream.
+struct Stream {
+    mode: Mode,
+    stream: z_stream,
 }
 
-pub struct Archive<RW> {
-    /// Whether the stream has been initialized.
-    init: bool,
-
-    /// Associated Zlib compression stream.
-    stream: libz_sys::z_streamp,
-
-    /// Underlying file, either read or write.
-    file: RW,
-}
-
-impl Default for Member {
-    fn default() -> Self {
-        Self {
-            method: Method::Deflate,
-            flags: 0,
-            mtime: 0,
-            extra_field: None,
-            name: None,
-            comment: None,
-            crc_16: None,
-            data: vec![],
-            crc_32: 0,
-            size: 0,
+impl Drop for Stream {
+    fn drop(&mut self) {
+        unsafe {
+            match self.mode {
+                Mode::DEFLATE => deflateEnd(self.into()),
+                Mode::INFLATE => inflateEnd(self.into()),
+            };
         }
     }
 }
 
-/// If opened on a writer, then write headers and compress data.
-impl<RW> Write for Archive<RW>
+impl AsRef<z_stream> for Stream {
+    fn as_ref(&self) -> &z_stream {
+        &self.stream
+    }
+}
+
+impl Into<z_streamp> for &mut Stream {
+    fn into(self) -> z_streamp {
+        &mut self.stream
+    }
+}
+
+/// Lightweight reference to z_streamp for the given [Stream].
+impl AsMut<z_streamp> for Stream {
+    fn as_mut(&mut self) -> &mut z_streamp {
+        // &mut addr_of_mut!(self.stream);
+        todo!()
+    }
+}
+
+impl AsRef<z_streamp> for Stream {
+    fn as_ref(&self) -> &z_streamp {
+        // self.into()
+        todo!()
+    }
+}
+
+impl Stream {
+    fn default_stream() -> z_stream {
+        unsafe {
+            z_stream {
+                zalloc: mem_alloc,
+                zfree: mem_free,
+                opaque: null_mut(),
+                next_in: todo!(),
+                avail_in: todo!(),
+                total_in: todo!(),
+                next_out: todo!(),
+                avail_out: todo!(),
+                total_out: todo!(),
+                msg: todo!(),
+                state: todo!(),
+                data_type: todo!(),
+                adler: todo!(),
+                reserved: todo!(),
+            }
+        }
+    }
+
+    fn new(mode: Mode) -> Self {
+        Self {
+            mode,
+            stream: Self::default_stream(),
+        }
+    }
+}
+
+pub struct Reader<R: Read> {
+    /// Associated Zlib compression stream.
+    stream: libz_sys::z_streamp,
+
+    /// Underlying file, either read or write.
+    file: R,
+}
+
+impl<R> Read for Reader<R>
 where
-    RW: Write,
+    R: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        unsafe {
+            inflate(self.stream, 1);
+            todo!()
+        }
+    }
+}
+
+pub struct Writer<W: Write> {
+    /// Associated Zlib compression stream.
+    stream: Stream,
+
+    /// Underlying file, either read or write.
+    file: W,
+}
+
+impl<W> Write for Writer<W>
+where
+    W: Write,
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         todo!()
@@ -125,133 +145,14 @@ where
     }
 }
 
-/// If opened on a reader, then read decompressed data.
-impl<RW> Read for Archive<RW>
+impl<W> Writer<W>
 where
-    RW: Read,
+    W: Write,
 {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        todo!()
-    }
-}
-
-/// Unifying trait for DEFLATE stream reading and writing.
-trait Deflatable<RW> {
-    fn initialize_stream(&mut self) -> io::Result<usize>;
-}
-
-/// Deflate implementation.
-impl<U> Archive<U>
-where
-    U: Write,
-{
-    /// Initialize the underlying libz stream for this [Archive].
-    fn initialize_stream(&mut self) -> io::Result<usize> {
-        unsafe {
-            match deflateInit_(self.stream, 0, libz_sys::zlibVersion(), 4096) {
-                Z_MEM_ERROR => Err(io::ErrorKind::OutOfMemory.into()),
-                Z_STREAM_ERROR => Err(io::ErrorKind::Other.into()),
-                Z_VERSION_ERROR => Err(io::ErrorKind::Other.into()),
-                _ => Ok(0),
-            }
+    pub fn new(writer: W) -> Self {
+        Self {
+            stream: Stream::new(Mode::DEFLATE),
+            file: writer,
         }
-    }
-}
-
-impl<T, U> Deflatable<T> for Archive<U>
-where
-    T: Read,
-{
-    /// Initialize the underlying libz stream for this [Archive].
-    fn initialize_stream(&mut self) -> io::Result<usize> {
-        unsafe {
-            match inflateInit_(self.stream, zlibVersion(), 4096) {
-                Z_MEM_ERROR => Err(io::ErrorKind::OutOfMemory.into()),
-                Z_STREAM_ERROR => Err(io::ErrorKind::Other.into()),
-                Z_VERSION_ERROR => Err(io::ErrorKind::Other.into()),
-                _ => Ok(0),
-            }
-        }
-    }
-}
-
-/// Optional associated data to a [Member].
-#[derive(Debug, Clone)]
-pub struct Subfield {
-    pub id: SubfieldId,
-    len: u32,
-    data: Vec<u8>,
-}
-
-/// Available subfield IDs.
-#[derive(Debug, Clone, Copy)]
-pub enum SubfieldId {
-    Apollo,
-}
-
-impl Into<[u8; 2]> for SubfieldId {
-    fn into(self) -> [u8; 2] {
-        match self {
-            Self::Apollo => [0x41, 0x70],
-        }
-    }
-}
-
-/// Compression methods
-#[derive(Debug, Clone, Copy)]
-#[repr(u8)]
-pub enum Method {
-    Store = 0,
-    Compress = 1,
-    Pack = 2,
-    Lzh = 3,
-    Deflate = 8,
-    MaxMethods = 9,
-}
-
-impl Into<u8> for Method {
-    fn into(self) -> u8 {
-        self as u8
-    }
-}
-
-/// Gzip flag bytes
-#[derive(Debug, Clone, Copy)]
-#[repr(u8)]
-enum Flag {
-    /// File probably ASCII text. (FTEXT)
-    Ascii = 1,
-
-    /// CRC16 for the gzip header. (FHCRC)
-    HeaderCrc = 1 << 1,
-
-    /// Extra field present. (FEXTRA)
-    ExtraField = 1 << 2,
-
-    /// Original file name present. (FNAME)
-    OriginalName = 1 << 3,
-
-    /// A zero-terminated file comment is present.
-    Comment = 1 << 4,
-
-    /// The highest three bits of the flag field are zero.
-    Reserved = 0,
-}
-
-impl Into<u8> for Flag {
-    fn into(self) -> u8 {
-        self as u8
-    }
-}
-
-#[derive(Debug)]
-pub enum Error {
-    IO(io::Error),
-    Custom(&'static str),
-}
-
-impl From<io::Error> for Error {
-    fn from(e: io::Error) -> Self {
-        Self::IO(e)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,20 @@ struct Stream {
     stream: z_stream,
 }
 
+/// Opaque data passed between calls to malloc and free by the system zlib.
+#[repr(C)]
+#[derive(Debug, Clone)]
+struct Opaque;
+
+impl Opaque {
+    /// Get the *mut c_void pointer for the given [Opaque].
+    unsafe fn into_void(mut self) -> *mut c_void {
+        &mut self as *mut _ as *mut c_void
+    }
+}
+
 impl Drop for Stream {
+    /// Shutdown the stream and any relevant resources in use by it.
     fn drop(&mut self) {
         unsafe {
             match self.mode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,17 +81,17 @@ impl Stream {
                 zalloc: mem_alloc,
                 zfree: mem_free,
                 opaque: null_mut(),
-                next_in: todo!(),
-                avail_in: todo!(),
-                total_in: todo!(),
-                next_out: todo!(),
-                avail_out: todo!(),
-                total_out: todo!(),
-                msg: todo!(),
-                state: todo!(),
-                data_type: todo!(),
-                adler: todo!(),
-                reserved: todo!(),
+                next_in: null_mut(),
+                avail_in: 0,
+                total_in: 0,
+                next_out: null_mut(),
+                avail_out: 0,
+                total_out: 0,
+                msg: null_mut(),
+                state: null_mut(),
+                data_type: 0,
+                adler: 0,
+                reserved: 0,
             }
         }
     }
@@ -102,14 +102,50 @@ impl Stream {
             stream: Self::default_stream(),
         }
     }
+
+    fn init_inflate(&mut self) -> Result<(), ()> {
+        assert_eq!(self.mode, Mode::INFLATE);
+        let res = inflateInit_(&mut self.stream);
+        if res == Z_OK {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    fn init_deflate(&mut self, level: i32, version: &[u8], stream_size: i32) -> Result<(), ()> {
+        assert_eq!(self.mode, Mode::DEFLATE);
+        let res = deflateInit_(&mut self.stream, level, version.as_ptr(), stream_size);
+        if res == Z_OK {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
 }
 
 pub struct Reader<R: Read> {
     /// Associated Zlib compression stream.
-    stream: libz_sys::z_streamp,
+    stream: Stream,
 
     /// Underlying file, either read or write.
     file: R,
+
+    /// Buffer for input file.
+    buf: Vec<u8>,
+}
+
+impl<R: Read> Reader<R> {
+    fn new(file: R, buf_len: usize) -> Self<R> {
+        let stream = Stream::new(Mode::INFLATE);
+        stream.init_inflate();
+
+        Self {
+            stream,
+            file,
+            buf: vec![0; buf_len],
+        }
+    }
 }
 
 impl<R> Read for Reader<R>
@@ -117,10 +153,17 @@ where
     R: Read,
 {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        unsafe {
-            inflate(self.stream, 1);
-            todo!()
+        if self.stream.avail_in == 0 {
+            self.stream.avail_in = self.file.read(&mut self.buf)?;
+            self.stream.next_in = self.buf.as_mut_ptr();
         }
+        self.stream.avail_out = buf.len();
+        self.stream.next_out = buf.as_mut_ptr();
+        unsafe {
+            let res = inflate(&mut self.stream, Z_NO_FLUSH);
+        }
+        let len = buf.len() - self.stream.avail_out;
+        Ok(len)
     }
 }
 
@@ -130,6 +173,9 @@ pub struct Writer<W: Write> {
 
     /// Underlying file, either read or write.
     file: W,
+
+    /// Buffer for output file.
+    buf: Vec<u8>,
 }
 
 impl<W> Write for Writer<W>
@@ -137,11 +183,22 @@ where
     W: Write,
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        todo!()
+        self.stream.avail_in = buf.len();
+        self.stream.next_in = buf.as_mut_ptr();
+        self.stream.avail_out = self.buf.len();
+        self.stream.next_out = self.buf.as_mut_ptr();
+        unsafe {
+            let res = deflate(&mut self.stream, Z_NO_FLUSH);
+        }
+        let out_len = self.buf.len() - self.stream.avail_out;
+        self.file.write(&self.buf[..out_len])?;
+        let in_len = buf.len() - self.stream.avail_in;
+        Ok(in_len)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        todo!()
+        // TODO: flush stream
+        self.file.flush()
     }
 }
 
@@ -149,10 +206,14 @@ impl<W> Writer<W>
 where
     W: Write,
 {
-    pub fn new(writer: W) -> Self {
+    pub fn new(writer: W, buf_len: usize, level: i32, version: &[u8], stream_size: i32) -> Self {
+        let stream = Stream::new(Mode::DEFLATE);
+        stream.init_deflate(level, version, stream_size);
+
         Self {
-            stream: Stream::new(Mode::DEFLATE),
+            stream,
             file: writer,
+            buf: vec![0; buf_len],
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,257 @@
+//! An [RFC 1952](https://datatracker.ietf.org/doc/html/rfc1952)-correct description
+//! of the gzip file format in Rust.
+
+use std::{
+    convert,
+    io::{self, Read, Write},
+    result,
+};
+
+use libz_sys::*;
+
+/// Magic number identifying a gzip archive.
+const GZIP_MAGIC: [u8; 2] = [0o037, 0o213];
+/// Magic number for older gzip archives.
+const OLD_GZIP_MAGIC: [u8; 2] = [0o37, 0o236];
+const LZH_MAGIC: [u8; 2] = [0o037, 0o236];
+const PKZIP_MAGIC: [u8; 4] = [0o120, 0o113, 0o003, 0o004];
+
+/// OS codes used by the gzip format.
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum OsCode {
+    FAT = 0,
+    AMIGA = 1,
+    VMS = 2,
+    UNIX = 3,
+    VMCMS = 4,
+    ATARI = 5,
+    HPFS = 6,
+    MACINTOSH = 7,
+    ZSYSTEM = 8,
+    CPM = 9,
+    TOPS = 10,
+
+    /// Windows' preferred file system. The successor to FAT.
+    NTFS = 11,
+
+    QDOS = 12,
+    ACORN = 13,
+
+    /// Provided for historical reasons.
+    UNKNOWN = 255,
+}
+
+/// A member in a gzip file.
+///
+/// A gzip file consists of a series of "members" (compressed data sets). The
+/// format of each member is specified in the following data structure.
+/// The members simply appear one after another in the file,
+/// with no additional information before, between, or after them.
+///
+/// See: [RFC 1952](https://datatracker.ietf.org/doc/html/rfc1952)
+#[derive(Debug, Clone)]
+pub struct Member {
+    /// Method used in compressing this member.
+    method: Method,
+
+    /// One-hot byte enabling extra fields in a gzip member.
+    flags: u8,
+
+    /// Most recent modification time of the compressed file.
+    mtime: u32,
+
+    /// Provided if [Flag::ExtraField] is set.
+    extra_field: Option<Subfield>,
+
+    /// Zero-terminated string containing the original file name, if [Flag::Name] is set.
+    name: Option<String>,
+
+    /// Zero-terminated file comment, if [Flag::Comment] is set.
+    comment: Option<String>,
+
+    /// CRC-16 of the gzip header, provided if [Flag::HeaderCrc] is set.
+    crc_16: Option<u16>,
+
+    /// Data associated with this member.
+    data: Vec<u8>,
+
+    /// CRC-32 of the original, uncompressed file.
+    crc_32: u32,
+
+    /// Size of the original, uncompressed file mod 2^32.
+    size: u32,
+}
+
+pub struct Archive<RW> {
+    /// Whether the stream has been initialized.
+    init: bool,
+
+    /// Associated Zlib compression stream.
+    stream: libz_sys::z_streamp,
+
+    /// Underlying file, either read or write.
+    file: RW,
+}
+
+impl Default for Member {
+    fn default() -> Self {
+        Self {
+            method: Method::Deflate,
+            flags: 0,
+            mtime: 0,
+            extra_field: None,
+            name: None,
+            comment: None,
+            crc_16: None,
+            data: vec![],
+            crc_32: 0,
+            size: 0,
+        }
+    }
+}
+
+/// If opened on a writer, then write headers and compress data.
+impl<RW> Write for Archive<RW>
+where
+    RW: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        todo!()
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        todo!()
+    }
+}
+
+/// If opened on a reader, then read decompressed data.
+impl<RW> Read for Archive<RW>
+where
+    RW: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        todo!()
+    }
+}
+
+/// Unifying trait for DEFLATE stream reading and writing.
+trait Deflatable<RW> {
+    fn initialize_stream(&mut self) -> io::Result<usize>;
+}
+
+/// Deflate implementation.
+impl<U> Archive<U>
+where
+    U: Write,
+{
+    /// Initialize the underlying libz stream for this [Archive].
+    fn initialize_stream(&mut self) -> io::Result<usize> {
+        unsafe {
+            match deflateInit_(self.stream, 0, libz_sys::zlibVersion(), 4096) {
+                Z_MEM_ERROR => Err(io::ErrorKind::OutOfMemory.into()),
+                Z_STREAM_ERROR => Err(io::ErrorKind::Other.into()),
+                Z_VERSION_ERROR => Err(io::ErrorKind::Other.into()),
+                _ => Ok(0),
+            }
+        }
+    }
+}
+
+impl<T, U> Deflatable<T> for Archive<U>
+where
+    T: Read,
+{
+    /// Initialize the underlying libz stream for this [Archive].
+    fn initialize_stream(&mut self) -> io::Result<usize> {
+        unsafe {
+            match inflateInit_(self.stream, zlibVersion(), 4096) {
+                Z_MEM_ERROR => Err(io::ErrorKind::OutOfMemory.into()),
+                Z_STREAM_ERROR => Err(io::ErrorKind::Other.into()),
+                Z_VERSION_ERROR => Err(io::ErrorKind::Other.into()),
+                _ => Ok(0),
+            }
+        }
+    }
+}
+
+/// Optional associated data to a [Member].
+#[derive(Debug, Clone)]
+pub struct Subfield {
+    pub id: SubfieldId,
+    len: u32,
+    data: Vec<u8>,
+}
+
+/// Available subfield IDs.
+#[derive(Debug, Clone, Copy)]
+pub enum SubfieldId {
+    Apollo,
+}
+
+impl Into<[u8; 2]> for SubfieldId {
+    fn into(self) -> [u8; 2] {
+        match self {
+            Self::Apollo => [0x41, 0x70],
+        }
+    }
+}
+
+/// Compression methods
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum Method {
+    Store = 0,
+    Compress = 1,
+    Pack = 2,
+    Lzh = 3,
+    Deflate = 8,
+    MaxMethods = 9,
+}
+
+impl Into<u8> for Method {
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Gzip flag bytes
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+enum Flag {
+    /// File probably ASCII text. (FTEXT)
+    Ascii = 1,
+
+    /// CRC16 for the gzip header. (FHCRC)
+    HeaderCrc = 1 << 1,
+
+    /// Extra field present. (FEXTRA)
+    ExtraField = 1 << 2,
+
+    /// Original file name present. (FNAME)
+    OriginalName = 1 << 3,
+
+    /// A zero-terminated file comment is present.
+    Comment = 1 << 4,
+
+    /// The highest three bits of the flag field are zero.
+    Reserved = 0,
+}
+
+impl Into<u8> for Flag {
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    IO(io::Error),
+    Custom(&'static str),
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self::IO(e)
+    }
+}


### PR DESCRIPTION
This is a draft PR for a lightweight Rust-safe wrapper around the system installation of zlib, linked by [`libz-sys`](https://crates.io/crates/libz-sys). The only real point of concern is the [`Stream`](https://github.com/uclaacm/gzip/blob/lib/src/lib.rs#L34) data type, which will wrap our `DEFLATE`-or.

There are a few concerns that I would like to address in conjunction with someone else:
* Use of `libc`, concerning the zlib `zalloc` and `zfree` functions in the stream structure. I believe that @Daniel-Liu-c0deb0t can be a good counsel on this. I haven't had to step too much out of pure Rust.
* Use of `opaque`. Once again, there is a raw pointer passed around by the zlib stream data type, and I'd like to get a better feel for how this works.

Past this, the implementations for `Reader` and `Writer` will be simple wrappers around some underlying `Read` or `Write` types using the Rust-safe `Stream`.

Our gzip headers will have to be implemented in another way. I have an earlier commit, yanked from [`krashanoff/rfc1952`](https://github.com/uclaacm/gzip/blob/krashanoff/rfc1952/src/lib.rs) that provided an ergonomic description of the gzip metadata, but I tossed it after we swapped from `flate2` to `libz-sys`. Still worth checking out. Tag is 24792cc0c90080b80db5819308da19aacef992a7. **I'll be cherry-picking these changes into this branch.**